### PR TITLE
161 example

### DIFF
--- a/Dockerfile-backend
+++ b/Dockerfile-backend
@@ -40,7 +40,7 @@ COPY mljob/requirements.txt .
 # install packages using conda, one at a time
 # the requirements file is in pip format, not conda, so need to install one a time 
 RUN conda install -y conda=${CONDA_VERSION} python=${PYTHON_VERSION} pip && \
-    for p in `cat mljob/requirements.txt` ; do conda install -y -c conda-forge $p; done && \
+    for p in `cat requirements.txt` ; do conda install -y -c conda-forge $p; done && \
     conda clean -aqy && \
     rm -rf ~/miniconda/pkgs && \
     find ~/miniconda/ -type d -name __pycache__ -prune -exec rm -rf {} \;


### PR DESCRIPTION
rather than create example from the app, use a shell script to convert an existing job into the example job.  Downside for now is that the example job does not have a name other than "example"