### PR TITLE
198 rerunexample

### DIFF
--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -3,50 +3,135 @@
 {% block title %}About{% endblock %}
 
 {% block app_content %}
-    <div>
-        <div id="content-padding" class="ps-3 pe-4 pt-2">
-            <h1 id="about-geneplexus">About GenePlexus</h1>
-            <h2 id="description">Description</h2>
-            <p>The GenePlexus webserver enables users to predict novel genes similar to their genes of interest based on their patterns of connectivity in human genome-scale molecular interaction networks.</p>
-            <p>A user can supply a list of genes of their interest to GenePlexus and select a gene network of their choice. GenePlexus will then train a machine learning model that captures the patterns of network connectivity of the user-defined genes in contrast to other genes in the network. This machine learning model is then used to return a prediction of how associated every gene in the network is to the input gene list based on their network connectivity patterns. Additionally, GenePlexus also enables the user to interpret the custom trained machine-learning model by comparing it to pretrained models for various bioloical processes (defined based on the <a href="http://geneontology.org/">Gene Ontology</a>) and diseases (defined based on curations from <a href="https://www.disgenet.org/">DisGeNet</a> terms). Users can visualize the top predictions in the form of an interactive network graph and download/export all the results in multiple convenient formats.</p>
-            <h3 id="brief-overview-of-the-inputs-and-outputs">Brief overview of the inputs and outputs</h3>
-            <h4 id="inputs">Inputs</h4>
-            <p>Users need to provide the following inputs:</p>
-            <ul>
+<div>
+    <div id="content-padding" class="ps-3 pe-4 pt-2">
+        <h1 id="about-geneplexus">About GenePlexus</h1>
+
+        <h2 id="description">Description</h2>
+
+        <p>The GenePlexus webserver enables users to predict novel genes similar to their genes of interest based on
+            their patterns of connectivity in human genome-scale molecular interaction networks.</p>
+        <p>A user can supply a list of genes of their interest to GenePlexus and select a gene network of their choice.
+            GenePlexus will then train a machine learning model that captures the patterns of network connectivity of
+            the user-defined genes in contrast to other genes in the network. This machine learning model is then used
+            to return a prediction of how associated every gene in the network is to the input gene list based on their
+            network connectivity patterns. Additionally, GenePlexus also enables the user to interpret the custom
+            trained machine-learning model by comparing it to pretrained models for various bioloical processes (defined
+            based on the <a href="http://geneontology.org/">Gene Ontology</a>) and diseases (defined based on curations
+            from <a href="https://www.disgenet.org/">DisGeNet</a> terms). Users can visualize the top predictions in the
+            form of an interactive network graph and download/export all the results in multiple convenient formats.</p>
+
+        <h3 id="brief-overview-of-the-inputs-and-outputs">Brief overview of the inputs and outputs</h3>
+
+        <h4 id="inputs">Inputs</h4>
+        <p>Users need to provide the following inputs:</p>
+        <ul>
             <li>A list of human genes.</li>
-            <li>A choice of a human genome-scale molecular network: <a href="https://thebiogrid.org/">BioGRID</a>, <a href="https://string-db.org/">STRING</a>, <a href="http://giant.princeton.edu/">GIANT-TN</a>, or <a href="https://string-db.org/">STRING-EXP</a>.</li>
-            <li>A choice of how the network connections are represented as features in the supervised machine learning model: Adjacency, Influence, or Embedding.</li>
-            <li>A choice of whether the input genes represent a cellular process/pathway or a disease. This choice informs what other genes in the network GenePlexus will use (as the &quot;negative class&quot;) to contrast against the user-provided genes (the &quot;positive class&quot;).</li>
+            <li>A choice of a human genome-scale molecular network: <a href="https://thebiogrid.org/">BioGRID</a>, <a
+                    href="https://string-db.org/">STRING</a>, <a href="http://giant.princeton.edu/">GIANT-TN</a>, or <a
+                    href="https://string-db.org/">STRING-EXP</a>.</li>
+            <li>A choice of how the network connections are represented as features in the supervised machine learning
+                model: Adjacency, Influence, or Embedding.</li>
+            <li>A choice of whether the input genes represent a cellular process/pathway or a disease. This choice
+                informs what other genes in the network GenePlexus will use (as the &quot;negative class&quot;) to
+                contrast against the user-provided genes (the &quot;positive class&quot;).</li>
             <li>A unique user supplied job name (optional).</li>
-            </ul>
-            <h4 id="outputs">Outputs</h4>
-            <p>GenePlexus uses the inputs provided by the user to return the following outputs:</p>
-            <ul>
-            <li>A prediction for every gene in the network on whether it belongs to the positive class, as defined by the user-supplied input gene file.</li>
-            <li>The similarity of the custom machine-learning model (trained on the user-supplied input gene file) to other machine-learning models trained using lists of genes annotated to biological process terms in the <a href="http://geneontology.org/">Gene Ontology</a> or diseases in the <a href="https://www.disgenet.org/">DisGeNet</a> database.</li>
+        </ul>
+
+        <h4 id="outputs">Outputs</h4>
+        <p>GenePlexus uses the inputs provided by the user to return the following outputs:</p>
+        <ul>
+            <li>A prediction for every gene in the network on whether it belongs to the positive class, as defined by
+                the user-supplied input gene file.</li>
+            <li>The similarity of the custom machine-learning model (trained on the user-supplied input gene file) to
+                other machine-learning models trained using lists of genes annotated to biological process terms in the
+                <a href="http://geneontology.org/">Gene Ontology</a> or diseases in the <a
+                    href="https://www.disgenet.org/">DisGeNet</a> database.</li>
             <li>An interactive graph of the network connectivity of the genes with the highest prediction scores</li>
-            <li>A summary table of how the user-supplied input gene list is converted to <a href="https://www.ncbi.nlm.nih.gov/Web/Search/entrezfs.html">Entrez</a> gene identifiers and which of those <a href="https://www.ncbi.nlm.nih.gov/Web/Search/entrezfs.html">Entrez</a> genes were in the chosen network.</li>
-            </ul>
-            <p>For detailed information on the inputs and outputs see the <a href="add link to help page here">Help page</a>.</p>
-            <h2 id="overview-of-the-working-and-motivation-of-geneplexus">Overview of the working and motivation of GenePlexus</h2>
-            <p>The goal of GenePlexus is, given a list of genes, predict the association of any gene in the human genome to that list of genes based on the patterns of their connectivity in an underlying genome-scale gene interaction network. This goal is accomplished by casting this as a binary classification machine learning problem, where the user-supplied gene list is considered the &quot;positive class&quot;, and a set of carefully chosen genes are automatically assigned to the &quot;negative class&quot;. GenePlexus then uses a <a href="https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html">regularized logistic regression classifier</a> to train the model that can distinguish genes in the positive class from the negative class.</p>
-            <p>The motivation for this network-based approach comes from the difficulty in choosing what features to use for a given machine learning problem. For example, if one wanted to predict if someone was a Democrat or a Republican then maybe choosing features such as state lived in, age, income, etc., might make sense. However, what would be a good feature set to use to predict if a person would like the movie Cinderella? Would the same feature set be able to be used to predict if someone wanted to buy a refrigerator? A powerful method is to forgo traditional feature design and instead use the behaviors/preferences of people within a social network to make predictions. When the problem is cast this way, the features of the machine learning model are always the same; the connections of people to each other in the social network. The only thing that changes with each machine learning problem is the definition of what constitutes the positive and negative classes.</p>
-            <p>Designing a feature set for a given problem in genetics is very difficult, but luckily biologists have been studying the interaction of genes and proteins for many years and there exist genome-wide scale molecular networks representing this vast knowledge. GenePlexus uses these networks as the features in its machine learning models, and the user defines the machine learning problem they want to solve by supplying the genes that belong to the positive class and indicating the type of genes that should constitute the negative class. Once these classes are defined, GenePlexus spins up a virtual machine that can handle the GBs worth of data used to train a machine-learning model specific to the user-supplied gene list. Interactive results are then retrievable using the custom job name provided upon running the model.</p>
-            <h2 id="previous-published-work-that-has-used-this-approach-of-network-based-gene-classification">Previous published works that have used this approach of network-based gene classification</h2>
-            <ul>
-            <li>Liu R, Mancuso CA, Yannakopoulos A, Johnson KA, Krishnan A. (2020) <a href="https://academic.oup.com/bioinformatics/article/36/11/3457/5780279">Supervised learning is an accurate method for network-based gene classification</a> <em>Bioinformatics</em> 36:3457-3465.</li>
-            <li>Krishnan A, Zhang R, Yao V, Theesfeld CL, Wong AK, Tadych A, Volfovsky N, Packer A, Lash A, Troyanskaya OG. (2016) <a href="https://www.nature.com/articles/nn.4353">Genome-wide prediction and functional characterization of the genetic basis of autism spectrum disorder</a> <em>Nature Neuroscience</em> 19:1454-1462.</li>
-            <li>Greene CS, Krishnan A, Wong AK, Ricciotti E, Zelaya RA, Himmelstein DS, Zhang R, Hartmann BM, Zaslavsky E, Sealfon SC, Chasman DI, FitzGerald GA, Dolinski K, Grosser T, Troyanskaya OG. (2015) <a href="https://www.nature.com/articles/ng.3259">Understanding multicellular function and disease with human tissue-specific networks.</a> <em>Nature Genetics</em> 47:569-576.</li>
-            </ul>
-            <h2 id="license">License</h2>
-            <p>The results of the GenePlexus webserver are licensed under the <a href="https://creativecommons.org/licenses/by/4.0/legalcode">Creative Commons License: Attribution 4.0 International</a></p>
+            <li>A summary table of how the user-supplied input gene list is converted to <a
+                    href="https://www.ncbi.nlm.nih.gov/Web/Search/entrezfs.html">Entrez</a> gene identifiers and which
+                of those <a href="https://www.ncbi.nlm.nih.gov/Web/Search/entrezfs.html">Entrez</a> genes were in the
+                chosen network.</li>
+        </ul>
+        <p>For detailed information on the inputs and outputs see the <a href="add link to help page here">Help
+                page</a>.</p>
 
-            <h3 class="mt-3" id="website">Website Development</h3>
+        <h2 id="overview-of-the-working-and-motivation-of-geneplexus">Overview of the working and motivation of
+            GenePlexus</h2>
+        <p>The goal of GenePlexus is, given a list of genes, predict the association of any gene in the human genome to
+            that list of genes based on the patterns of their connectivity in an underlying genome-scale gene
+            interaction network. This goal is accomplished by casting this as a binary classification machine learning
+            problem, where the user-supplied gene list is considered the &quot;positive class&quot;, and a set of
+            carefully chosen genes are automatically assigned to the &quot;negative class&quot;. GenePlexus then uses a
+            <a href="https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html">regularized
+                logistic regression classifier</a> to train the model that can distinguish genes in the positive class
+            from the negative class.</p>
+        <p>The motivation for this network-based approach comes from the difficulty in choosing what features to use for
+            a given machine learning problem. For example, if one wanted to predict if someone was a Democrat or a
+            Republican then maybe choosing features such as state lived in, age, income, etc., might make sense.
+            However, what would be a good feature set to use to predict if a person would like the movie Cinderella?
+            Would the same feature set be able to be used to predict if someone wanted to buy a refrigerator? A powerful
+            method is to forgo traditional feature design and instead use the behaviors/preferences of people within a
+            social network to make predictions. When the problem is cast this way, the features of the machine learning
+            model are always the same; the connections of people to each other in the social network. The only thing
+            that changes with each machine learning problem is the definition of what constitutes the positive and
+            negative classes.</p>
+        <p>Designing a feature set for a given problem in genetics is very difficult, but luckily biologists have been
+            studying the interaction of genes and proteins for many years and there exist genome-wide scale molecular
+            networks representing this vast knowledge. GenePlexus uses these networks as the features in its machine
+            learning models, and the user defines the machine learning problem they want to solve by supplying the genes
+            that belong to the positive class and indicating the type of genes that should constitute the negative
+            class. Once these classes are defined, GenePlexus spins up a virtual machine that can handle the GBs worth
+            of data used to train a machine-learning model specific to the user-supplied gene list. Interactive results
+            are then retrievable using the custom job name provided upon running the model.</p>
 
-            <p>The GenePlexus backend code and pre-trained models were generated by Dr. Christopher Mancuso and Remy Liu, Department of Computational Mathematics, Science and Engineering, Michigan State University
+        <h2 id="previous-published-work-that-has-used-this-approach-of-network-based-gene-classification">Previous
+            published works that have used this approach of network-based gene classification</h2>
+        <ul>
+            <li>Liu R, Mancuso CA, Yannakopoulos A, Johnson KA, Krishnan A. (2020) <a
+                    href="https://academic.oup.com/bioinformatics/article/36/11/3457/5780279">Supervised learning is an
+                    accurate method for network-based gene classification</a> <em>Bioinformatics</em> 36:3457-3465.</li>
+            <li>Krishnan A, Zhang R, Yao V, Theesfeld CL, Wong AK, Tadych A, Volfovsky N, Packer A, Lash A, Troyanskaya
+                OG. (2016) <a href="https://www.nature.com/articles/nn.4353">Genome-wide prediction and functional
+                    characterization of the genetic basis of autism spectrum disorder</a> <em>Nature Neuroscience</em>
+                19:1454-1462.</li>
+            <li>Greene CS, Krishnan A, Wong AK, Ricciotti E, Zelaya RA, Himmelstein DS, Zhang R, Hartmann BM, Zaslavsky
+                E, Sealfon SC, Chasman DI, FitzGerald GA, Dolinski K, Grosser T, Troyanskaya OG. (2015) <a
+                    href="https://www.nature.com/articles/ng.3259">Understanding multicellular function and disease with
+                    human tissue-specific networks.</a> <em>Nature Genetics</em> 47:569-576.</li>
+        </ul>
+
+        <h2 id="license">License</h2>
+        <p>The results of the GenePlexus webserver are licensed under the <a
+                href="https://creativecommons.org/licenses/by/4.0/legalcode">Creative Commons License: Attribution 4.0
+                International</a></p>
+
+        
+        <h2 id="privacypolicy">Privacy Policy</h2>
+            <p> This website uses cookies to allow a loaded geneset to persist as the website is navigated as well as recall jobs that have been submitted. 
+            We do not use cookies for marketing, advertisement or tracking. By using our site you agree to use cookies only for the outlined purposes.
             </p>
-            <p>This GenePlexus website and cloud engineering was done by Douglas Krum, Patrick Bills, and Jacob Newsted, Data Science Group, Enterprise Services, Michigan State University. 
-            </p>
-        </div>
+            
+            <p>if optionally provide your email address with for notification when submitting jobs, you agree to allow us to use and store your email address with that 
+                job information.  We agree never to share your information outside of the application, and we will never use this information to send unsolicited 
+            email or without your consent.  </p>
+            <p>If you contact us via the project email account (  help[at]geneplexus.net ) your address will be used 
+            by project members to contact you.   </p>
+            <p>Any list of genes you input or upload is your data but is stored along with the job output, accessible to anyone 
+            with the job id.  We agree to never use this genelist for any other purposes out of use by this website.  
+            </p>    
+            <br>
+
+        <h3 class="mt-3" id="website">Website Development</h3>
+
+        <p>The GenePlexus backend code and pre-trained models were generated by Dr. Christopher Mancuso and Remy Liu,
+            Department of Computational Mathematics, Science and Engineering, Michigan State University
+        </p>
+        <p>This GenePlexus website and cloud engineering was done by Douglas Krum, Patrick Bills, and Jacob Newsted,
+            Data Science Group, Enterprise Services, Michigan State University.
+        </p>
+
+        
     </div>
+</div>
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -36,6 +36,7 @@
           
               <ul class="nav col-md-8 justify-content-end list-unstyled d-flex">
                 <li class="ms-3">Contact help[at]geneplexus.net</li>
+                <li class="ms-3"><a href="{{ url_for('about', _anchor='privacypolicy') }}">Privacy policy</a><li>
                 <li class="ms-3"><a class="" href="https://thekrishnanlab.org">Krishnan Lab</a></li>
               </ul>
         </footer>

--- a/app/templates/cookies.html
+++ b/app/templates/cookies.html
@@ -5,7 +5,10 @@
             <div class="toast-body p-4 d-flex flex-column">
                 <h4>Cookie Warning</h4>
                 <p>
-                This website uses cookies to allow a loaded geneset to persist as the website is navigated as well as recall jobs that have been submitted. We do not use cookies for marketing, advertisement or tracking. By using our site you agree to use cookies only for the outlined purposes.
+                This website uses cookies to allow a loaded geneset to persist as the website is navigated as well
+                as recall jobs that have been submitted. We do not use cookies for marketing, advertisement or tracking. 
+                By using our site you agree to use cookies only for the outlined purposes.  &nbsp;
+                <a href="{{ url_for('about', _anchor='privacypolicy') }}">Privacy policy</a>
                 </p>
                 <div class="ml-auto">
                 <button type="button" class="btn btn-light" id="btnAccept">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -59,7 +59,7 @@
     <!-- <hr class="mt-4"> -->
     <h4>Example</h4>
     <p>You can visit
-    <a href="{{url_for('job', jobname='example')}}">this page</a>
+    <a href="{{url_for('job', jobname='example%20(%20Primary%20Ciliary%20Dyskinesia%20)')}}">this page</a>
     to see the results of an example run where GenePlexus was used to train a model and predict novel genes associated with the disease <i>primary ciliary dyskinesia (PCD)</i>.</p>
     <p>This run used the adjacency matrix representation of the human STRING network. Since the input genes correspond to a disease, the negative genes were selected based on genes associated with other diseases (from the DisGeNet database).
         The predicted genes are under the “Gene Predictions” tab. It is notable that the gene DNALI1 (dynein axonemal light intermediate chain 1), which was not included in the original gene list, is strongly predicted to be associated with PCD.</p>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -59,7 +59,7 @@
     <!-- <hr class="mt-4"> -->
     <h4>Example</h4>
     <p>You can visit
-    <a href="{{url_for('job', jobname='example%20(%20Primary%20Ciliary%20Dyskinesia%20)')}}">this page</a>
+    <a href="{{url_for('job', jobname='example')}}">this page</a>
     to see the results of an example run where GenePlexus was used to train a model and predict novel genes associated with the disease <i>primary ciliary dyskinesia (PCD)</i>.</p>
     <p>This run used the adjacency matrix representation of the human STRING network. Since the input genes correspond to a disease, the negative genes were selected based on genes associated with other diseases (from the DisGeNet database).
         The predicted genes are under the “Gene Predictions” tab. It is notable that the gene DNALI1 (dynein axonemal light intermediate chain 1), which was not included in the original gene list, is strongly predicted to be associated with PCD.</p>

--- a/app/templates/jobresults.html
+++ b/app/templates/jobresults.html
@@ -82,7 +82,7 @@
         <div class="box_padding">
             <div class="row">
                 <div class="col text-left">
-                    <label><b>Job Name:</b>&nbsp</label>{{( jobname )}}<br>
+                    <label><b>Job Name:</b>&nbsp</label>{{( job_output['jobname'] )}}<br>
                 </div>
                 <div class="col text-left">
                     <label><b>Network:</b>&nbsp</label>{{ job_output['net_type'] }}<br>

--- a/copy_job_for_example.sh
+++ b/copy_job_for_example.sh
@@ -2,29 +2,34 @@
 
 # this will take an existing job and put it as the example 
 # this assumes the env var $JOB_PATH is set ( use source .env to set it )
-# check for parameter
+# TODO check for parameter
+
 export EXAMPLEJOB=$1
-export EXAMPLENAME="example ( Primary Ciliary Dyskinesia )"
+export EXAMPLENAME="example"  #  ( Primary Ciliary Dyskinesia )"
 cp -R "$JOB_PATH/$EXAMPLEJOB" "$JOB_PATH/$EXAMPLENAME"
 cd  "$JOB_PATH/$EXAMPLENAME"
 # rename all the files
 
-for f in $JOB_PATH/${EXAMPLEJOB}*.*; do 
+for f in ${EXAMPLEJOB}*.*; do 
     newname=${f/"$EXAMPLEJOB"/"$EXAMPLENAME"}
     mv "$f" "$newname"
 done
 
+# for this special example job, changing the name that's displayed from the name (folder) of the job
+# normally they are the same
+# this is to have a complex name displayed for the example page, but keep the URL simple to just /example
+export DISPLAYNAME="example ( Primary Ciliary Dyskinesia )"
 
 # some files have job names and job file paths ... replace those with sed
-sed_pattern="s/$EXAMPLEJOB/$EXAMPLENAME/g"
+sed_pattern="s/$EXAMPLEJOB/$DISPLAYNAME/g"
 sed -i "$sed_pattern" "$EXAMPLENAME.json"
 sed -i "$sed_pattern" job_info.json
 sed -i "$sed_pattern" results.html
     
 
 # make nicer jobs names in output files
-sed -i 's/"JOBNAME": "example"/"JOBNAME": "$EXAMPLENAME"/g' "$EXAMPLENAME.json"
-sed -i 's/"jobname": "example"/"jobname": "$EXAMPLENAME"/g' job_info.json 
+sed -i 's/"JOBNAME": "example"/"JOBNAME": "$DISPLAYNAME"/g' "$EXAMPLENAME.json"
+sed -i 's/"jobname": "example"/"jobname": "$DISPLAYNAME"/g' job_info.json 
 
 linkname=${EXAMPLENAME//" "/"%20"}
 

--- a/copy_job_for_example.sh
+++ b/copy_job_for_example.sh
@@ -9,7 +9,7 @@ cp -R "$JOB_PATH/$EXAMPLEJOB" "$JOB_PATH/$EXAMPLENAME"
 cd  "$JOB_PATH/$EXAMPLENAME"
 # rename all the files
 
-for f in ${EXAMPLEJOB}*.*; do 
+for f in "$JOB_PATH/${EXAMPLEJOB}*.*; do 
     newname=${f/"$EXAMPLEJOB"/"$EXAMPLENAME"}
     mv "$f" "$newname"
 done

--- a/copy_job_for_example.sh
+++ b/copy_job_for_example.sh
@@ -9,7 +9,7 @@ cp -R "$JOB_PATH/$EXAMPLEJOB" "$JOB_PATH/$EXAMPLENAME"
 cd  "$JOB_PATH/$EXAMPLENAME"
 # rename all the files
 
-for f in "$JOB_PATH/${EXAMPLEJOB}*.*; do 
+for f in $JOB_PATH/${EXAMPLEJOB}*.*; do 
     newname=${f/"$EXAMPLEJOB"/"$EXAMPLENAME"}
     mv "$f" "$newname"
 done


### PR DESCRIPTION
fixes #198 and #199.   Change to `jobresults.html` to allow for simple URL (example) but complex name ( in `jobinfo.json`) which only right now applies to the example.  See example on current dev site 